### PR TITLE
Fix type

### DIFF
--- a/src/dom/table.js
+++ b/src/dom/table.js
@@ -727,7 +727,7 @@
           doAdd = (!cell.isColspan || cell.firstCol);
         break;
         case "after":
-          doAdd = (!cell.isColspan || cell.lastCol || (cell.isColspan && c.el == this.cell));
+          doAdd = (!cell.isColspan || cell.lastCol || (cell.isColspan && cell.el == this.cell));
         break;
       }
 


### PR DESCRIPTION
`c` doesn't exist in this context. I think this is meant to be `cell.el` instead of `c.el`
